### PR TITLE
Rails 5.2 Support - Fixes deep symbolize keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ nbproject
 pkg
 *.swp
 spec/dummy
+.ruby-version

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,4 @@ end
 gem 'solidus_auth_devise'
 gem 'searchkick', '>= 1.2'
 
-gem 'codeclimate-test-reporter', group: :test, require: nil
-
 gemspec

--- a/lib/solidus_searchkick/version.rb
+++ b/lib/solidus_searchkick/version.rb
@@ -1,3 +1,3 @@
 module SolidusSearchkick
-  VERSION = '0.3.4'
+  VERSION = '0.4.0'
 end

--- a/solidus_searchkick.gemspec
+++ b/solidus_searchkick.gemspec
@@ -19,13 +19,13 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_runtime_dependency     'solidus', '>= 1.4.0'
+  s.add_runtime_dependency     'solidus', '~> 2.0'
   s.add_runtime_dependency     'searchkick', '>= 1.2'
 
   s.add_development_dependency 'capybara', '~> 2.4'
   s.add_development_dependency 'coffee-rails'
   s.add_development_dependency 'database_cleaner'
-  s.add_development_dependency 'factory_bot', '~> 4.5'
+  s.add_development_dependency 'factory_bot', '~> 4.10'
   s.add_development_dependency 'ffaker'
   s.add_development_dependency 'rspec-rails',  '~> 3.1'
   s.add_development_dependency 'sass-rails', '~> 5.0'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ require 'solidus_searchkick/factories'
 
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
-  config.include Devise::TestHelpers, type: :controller
+  config.include Devise::Test::ControllerHelpers, type: :controller
   # Infer an example group's spec type from the file location.
   config.infer_spec_type_from_file_location!
 


### PR DESCRIPTION
Originally opened in https://github.com/elevatorup/solidus_searchkick/pull/6

- Adds support for Rails 5.2
- Add support for Solidus 5.6.0
- Adds support for Searchkick 3.10
- All tests passing
- All deprecation warnings resolved
- Fixes #5