### PR TITLE
Improve how searcher_class is set

### DIFF
--- a/lib/solidus_searchkick/engine.rb
+++ b/lib/solidus_searchkick/engine.rb
@@ -11,11 +11,14 @@ module SolidusSearchkick
       g.test_framework :rspec
     end
 
+    initializer "solidus_auth_devise.set_user_class", after: :load_config_initializers do
+      Spree::Config.searcher_class = Spree::Search::Searchkick
+    end
+
     def self.activate
       Dir.glob(File.join(File.dirname(__FILE__), '../../app/**/*_decorator*.rb')) do |c|
         Rails.configuration.cache_classes ? require(c) : load(c)
       end
-      Spree::Config.searcher_class = Spree::Search::Searchkick
     end
 
     config.to_prepare &method(:activate).to_proc


### PR DESCRIPTION
Before the searcher_class was set after application included the gem was
loaded. By doing that, overriding the searcher_class in the solidus way
was not possible. In this commit I'm overriding this behaviour following
as done in
https://github.com/solidusio/solidus_auth_devise/blob/7a2703ebda371183fef4356c97a598215b7f0942/lib/spree/auth/engine.rb#L16-L18