### PR TITLE
Suggest to use Github gem version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add searchkick and solidus_searchkick to your Gemfile:
 
 ```ruby
 gem 'searchkick'
-gem 'solidus_searchkick'
+gem 'solidus_searchkick', github: 'solidusio-contrib/solidus_searchkick'
 ```
 
 Bundle your dependencies and run the installation generator:


### PR DESCRIPTION
Readme install instructions advise to use Rubygems which serves a version stuck to 2017 and published from the legacy repo. As long as we don't publish a new version to Rubygems, we should ask users to point to Github version.