### PR TITLE
Upgrade to Searchkick 5

### DIFF
--- a/app/models/spree/search/searchkick.rb
+++ b/app/models/spree/search/searchkick.rb
@@ -120,7 +120,7 @@ module Spree::Search
     end
 
     def includes_clause
-      includes_clause =  { master: [:currently_valid_prices] }
+      includes_clause =  { master: [:prices] }
       includes_clause[:master] << :images if include_images
       includes_clause
     end

--- a/solidus_searchkick.gemspec
+++ b/solidus_searchkick.gemspec
@@ -29,9 +29,10 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'searchkick', ['>= 1.2', '< 5']
+  s.add_dependency 'searchkick', ['>= 1.2']
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   s.add_dependency 'solidus_support', '~> 0.5'
+  s.add_dependency 'elasticsearch'
 
   s.add_development_dependency 'solidus_dev_support'
 end

--- a/solidus_searchkick.gemspec
+++ b/solidus_searchkick.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.executables = s.files.grep(%r{^exe/}) { |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'searchkick', '>= 1.2'
+  s.add_dependency 'searchkick', ['>= 1.2', '< 5']
   s.add_dependency 'solidus_core', ['>= 2.0.0', '< 4']
   s.add_dependency 'solidus_support', '~> 0.5'
 


### PR DESCRIPTION
This PR adds Elasticsearch as a dependency, which is now required in Searchkick upstream.